### PR TITLE
Issue 5 Fix false positives for misfire handling and classname

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -107,6 +107,7 @@ This plugin is a direct replacement for the `XMLSchedulingDataProcessorPlugin` p
 
 First you need a YAML file. The easiest way is to convert from your existing schedule. Or write one by hand using one of the examples here. 
 
+*Limitation:* The xml file allows multiple <schedule> elements. The Exporter Plugin only supports one.
 [source,yaml]
 ----
   yamlScheduleExporter:
@@ -114,7 +115,7 @@ First you need a YAML file. The easiest way is to convert from your existing sch
     exportFile: "${java.io.tmpdir}/schedule-export.yaml"
 ----
 
-== Configuring the plugin
+== Configuring the YAML plugin
 The Synchronizer plugin only needs 1 parameter, a list of YAML files defining
 the jobs and their triggers. If you use NativeJob (or other Quartz provided plugins which are risky, then they need to be configured).
 Disabling unsafe jobs by default is a means to prevent injection attacks if the schedule is loaded by another mechanism.

--- a/examples/spring-boot-3-quartz/src/test/java/be/sysa/quartz/initializer/fixtures/TemplateReplacement.java
+++ b/examples/spring-boot-3-quartz/src/test/java/be/sysa/quartz/initializer/fixtures/TemplateReplacement.java
@@ -7,6 +7,7 @@ import java.util.Optional;
 
 @AllArgsConstructor
 public class TemplateReplacement {
+
     String template;
 
     public static String def(String value, String defaultValue) {
@@ -23,32 +24,26 @@ public class TemplateReplacement {
         template = replaceLine(token, value);
     }
 
+    private String processLines(String token, Object value, boolean removeOnly) {
+        return template.lines()
+                .map(line -> {
+                    if (StringUtils.contains(line, token)) {
+                        return (removeOnly || value == null) ? null : String.valueOf(value);
+                    }
+                    return line;
+                })
+                .filter(StringUtils::isNotBlank) // Filter out null or blank lines
+                .reduce((line1, line2) -> line1 + System.lineSeparator() + line2)
+                .orElse("");
+    }
+
     private String replaceLine(String token, Object value) {
-        String[] lines = template.split(System.lineSeparator());
-        StringBuilder sb = new StringBuilder();
-        for (String line : lines) {
-            if (StringUtils.contains(line, token)) {
-                if (value != null) {
-                    sb.append(value);
-                }
-            } else {
-                sb.append(line).append(System.lineSeparator());
-            }
-        }
-        return sb.toString();
+        return processLines(token, value, false);
     }
 
     private String removeLine(String token) {
-        String[] lines = template.split(System.lineSeparator());
-        StringBuilder sb = new StringBuilder();
-        for (String line : lines) {
-            if (!StringUtils.contains(line, token)) {
-                sb.append(line).append(System.lineSeparator());
-            }
-        }
-        return sb.toString();
+        return processLines(token, null, true);
     }
-
 
     @Override
     public String toString() {

--- a/quartz-job-synchronizer/src/main/java/be/sysa/quartz/initializer/service/JobSynchronizer.java
+++ b/quartz-job-synchronizer/src/main/java/be/sysa/quartz/initializer/service/JobSynchronizer.java
@@ -139,6 +139,8 @@ public class JobSynchronizer {
                 .inTimeZone(triggerDefinition.getTimeZone());
         if (triggerDefinition.isMisfireExecution()) {
             scheduleBuilder.withMisfireHandlingInstructionFireAndProceed();
+        }else{
+            scheduleBuilder.withMisfireHandlingInstructionDoNothing();
         }
 
         String description = getDescription(triggerDefinition);

--- a/quartz-job-synchronizer/src/test/java/be/sysa/quartz/initializer/support/TriggerDifferencerTest.java
+++ b/quartz-job-synchronizer/src/test/java/be/sysa/quartz/initializer/support/TriggerDifferencerTest.java
@@ -1,6 +1,7 @@
 package be.sysa.quartz.initializer.support;
 
 import be.sysa.quartz.initializer.model.TriggerDefinition;
+import be.sysa.quartz.initializer.support.Difference.Type;
 import org.junit.jupiter.api.Test;
 import org.quartz.CronScheduleBuilder;
 import org.quartz.CronTrigger;
@@ -67,11 +68,6 @@ public class TriggerDifferencerTest {
         assertDifference(anotherTrigger, Difference.Type.TIMEZONE);
     }
 
-    @Test
-    public void misFireExecutionChanged() {
-        TriggerDefinition anotherTrigger = newTrigger.toBuilder().misfireExecution(false).build();
-        assertDifference(anotherTrigger, Difference.Type.MISFIRE_IGNORE); // TODO add the opposite case
-    }
 
     @Test
     public void priorityChanged() {

--- a/quartz-job-synchronizer/src/test/java/be/sysa/quartz/initializer/support/TriggerMisfireDifferenceTest.java
+++ b/quartz-job-synchronizer/src/test/java/be/sysa/quartz/initializer/support/TriggerMisfireDifferenceTest.java
@@ -1,0 +1,94 @@
+package be.sysa.quartz.initializer.support;
+
+import be.sysa.quartz.initializer.model.TriggerDefinition;
+import be.sysa.quartz.initializer.support.Difference.Type;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.quartz.CronScheduleBuilder;
+import org.quartz.CronTrigger;
+import org.quartz.JobKey;
+import org.quartz.TriggerKey;
+
+import java.util.TimeZone;
+import java.util.stream.Stream;
+
+import static be.sysa.quartz.initializer.support.Difference.Type.MISFIRE_EXECUTE_NOW;
+import static be.sysa.quartz.initializer.support.Difference.Type.MISFIRE_IGNORE;
+import static java.time.ZoneOffset.UTC;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.quartz.TriggerBuilder.newTrigger;
+
+public class TriggerMisfireDifferenceTest {
+    private static final String GROUP_NAME = "MyGroup";
+    private static final String JOB_NAME = "MyJob";
+    private static final String TRIGGER_NAME = "MyTrigger";
+    private static final TimeZone TIMEZONE = TimeZone.getTimeZone(UTC);
+    private static final String DESCRIPTION = "description";
+    private static final JobKey jobKey = JobKey.jobKey(JOB_NAME, GROUP_NAME);
+    private static final TriggerKey triggerKey = TriggerKey.triggerKey(TRIGGER_NAME, GROUP_NAME);
+
+    @ParameterizedTest
+    @MethodSource("testDifferencesData")
+    void testDifferences(CronTrigger triggerInSchedule, TriggerDefinition newDefinition, Type difference) {
+        if (difference == null) {
+            assertNoDifference(triggerInSchedule, newDefinition);
+        } else {
+            assertDifference(triggerInSchedule, newDefinition, difference);
+        }
+    }
+
+    private void assertNoDifference(CronTrigger triggerInSchedule, TriggerDefinition newDefinition) {
+        assertThat(Differencer.difference(triggerInSchedule, newDefinition).logDifferences()).isEmpty();
+    }
+
+    private void assertDifference(CronTrigger existingTrigger, TriggerDefinition newDefinition, Type difference) {
+        assertThat(Differencer.difference(existingTrigger, newDefinition).logDifferences()).hasSize(1)
+                .extracting(Difference::getType).contains(difference);
+    }
+
+    private static Stream<Arguments> testDifferencesData() {
+
+        TriggerDefinition misFireHandlingTrue;
+        TriggerDefinition misFireHandlingFalse;
+        CronTrigger ignoreMisfires;
+        CronTrigger fireAndProceed;
+        CronTrigger doNothing;
+
+        misFireHandlingTrue = TriggerDefinition.builder()
+                .jobkey(jobKey)
+                .triggerKey(triggerKey)
+                .cronExpression("0 1 10 ? * *")
+                .timeZone(TIMEZONE)
+                .priority(11)
+                .description(DESCRIPTION)
+                .misfireExecution(true)
+                .build();
+
+        misFireHandlingFalse = misFireHandlingTrue.toBuilder().misfireExecution(false).build();
+
+        ignoreMisfires = triggerFor(CronScheduleBuilder.dailyAtHourAndMinute(10, 1).inTimeZone(TIMEZONE).withMisfireHandlingInstructionIgnoreMisfires());
+        fireAndProceed = triggerFor(CronScheduleBuilder.dailyAtHourAndMinute(10, 1).inTimeZone(TIMEZONE).withMisfireHandlingInstructionFireAndProceed());
+        doNothing = triggerFor(CronScheduleBuilder.dailyAtHourAndMinute(10, 1).inTimeZone(TIMEZONE).withMisfireHandlingInstructionDoNothing());
+
+        return Stream.of(
+                Arguments.of(ignoreMisfires, misFireHandlingTrue, MISFIRE_EXECUTE_NOW),
+                Arguments.of(fireAndProceed, misFireHandlingTrue, null),
+                Arguments.of(doNothing, misFireHandlingTrue, MISFIRE_EXECUTE_NOW),
+                Arguments.of(ignoreMisfires, misFireHandlingFalse, null),
+                Arguments.of(fireAndProceed, misFireHandlingFalse, MISFIRE_IGNORE),
+                Arguments.of(doNothing, misFireHandlingFalse, null)
+        );
+    }
+
+    private static CronTrigger triggerFor(CronScheduleBuilder cronScheduleBuilder) {
+        return newTrigger()
+                .forJob(jobKey)
+                .withIdentity(triggerKey)
+                .withPriority(11)
+                .withDescription("DESCRIPTION")
+                .withSchedule(cronScheduleBuilder)
+                .build();
+    }
+
+}


### PR DESCRIPTION
…ding giving false positives in intellij

Added explicit support for handling 'fire and proceed' and 'do nothing' misfire instructions. Enhanced differencing logic to detect mismatches in misfire settings. Introduced new test suite, `TriggerMisfireDifferenceTest`, to ensure accurate detection of these differences.
[Trigger Misfire False Positive](https://github.com/mjeffrey/quartz-job-synchronizer/issues/6)

[Classname False Positive](https://github.com/mjeffrey/quartz-job-synchronizer/issues/7)
